### PR TITLE
event guard: redirect to root if error while loading event (may be 404)

### DIFF
--- a/src/app/event.guard.ts
+++ b/src/app/event.guard.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot } from '@angular/router';
+import { CanActivate, ActivatedRouteSnapshot, RouterStateSnapshot, UrlTree, Router } from '@angular/router';
 import { Observable, of } from 'rxjs';
 import { EventService } from './shared/event.service';
 import { map, catchError } from 'rxjs/operators';
@@ -9,11 +9,12 @@ import { map, catchError } from 'rxjs/operators';
 })
 export class EventGuard implements CanActivate {
 
-  constructor(private eventService: EventService) {
+  constructor(private eventService: EventService, private router: Router) {
   }
 
-  canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
+  canActivate(next: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
     const eventShortName = next.params['eventShortName'];
-    return this.eventService.getEvent(eventShortName).pipe(catchError(e => of(false)), map(e => e !== false));
+    return this.eventService.getEvent(eventShortName)
+      .pipe(catchError(e => of(this.router.parseUrl(''))), map(e => e instanceof UrlTree ? e : true));
   }
 }


### PR DESCRIPTION
Fix the behavior if no event is present: the guard will return false, and thus the client will show an empty page.

Now it will redirect to the root